### PR TITLE
Adding script fix

### DIFF
--- a/Installer/payload/Library/Application Support/SplashBuddy/SplashBuddy.launch.sh
+++ b/Installer/payload/Library/Application Support/SplashBuddy/SplashBuddy.launch.sh
@@ -8,8 +8,13 @@ doneFile="/Users/${loggedInUser}/Library/Containers/io.fti.SplashBuddy/Data/Libr
 # - SplashBuddy binary exists (is fully installed)
 # - User is in control (not _mbusersetup)
 # - User is on desktop (Finder process exists)
+# - Application is not already running
+function IsRunning()
+{
+pgrep "SplashBuddy" && return 1 || return 0
+}
 
-if [ -f "$app"/Contents/MacOS/SplashBuddy ] \
+if IsRunning && [ -f "$app"/Contents/MacOS/SplashBuddy ] \
 	&& [ "$loggedInUser" != "_mbusersetup" ] \
 	&& [ $(pgrep Finder | wc -l) -gt 0 ] \
 	&& [ ! -f "${doneFile}" ]; then


### PR DESCRIPTION
Fix an issue where the script would cause SplashBuddy to come forward and allow for possible password disclosure during after the change in focus.

Added:
- Checks to see if the application is running, and does not launch if it is already running.

Issues Solved:
- Change in focus if focus on one app, and application gets activated again
- Fixes the possibility of passwords or sensitive data from being exposed during key entry and the application focus gets changed.