### PR TITLE
Update Project Scheme to use the system language

### DIFF
--- a/SplashBuddy.xcodeproj/xcshareddata/xcschemes/SplashBuddy.xcscheme
+++ b/SplashBuddy.xcodeproj/xcshareddata/xcschemes/SplashBuddy.xcscheme
@@ -59,7 +59,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = "it"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Closes #46 

Thanks for the help, pointed me in the right direction. Much appreciated.

Updated the Project Scheme definition so that when running out of Xcode in Debug (instead of Release) it will use the System Language from the machine its running on instead of being set to Italian by default. 