### PR TITLE
fixed Dutch localization

### DIFF
--- a/SplashBuddy/Resources/de.lproj/Localizable.strings
+++ b/SplashBuddy/Resources/de.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "%@ failed to install. Support has been notified." = "%@ konnte nicht installiert werden. Der Support wurde benachrichtigt.";
 
 /* Everything was ok. There's no button. An automated action will happen (like force restart) */
-"All applications were installed. Finishing installation…" = "Alle Anwendungen installiert wurden. Abschluss der Installation...";
+"All applications were installed. Finishing installation…" = "Alle Anwendungen installiert wurden. Abschluss der Installation…";
 
 /* (No Comment) */
 "All applications were installed. Please click continue." = "Alle Programme wurden installiert. Bitte klicken Sie weiter.";
@@ -29,7 +29,7 @@
 "Continue" = "Weiter";
 
 /* (No Comment) */
-"Installing…" = "Installieren...";
+"Installing…" = "Installieren…";
 
 /* Label of the button for Logout */
 "Logout" = "Ausloggen";
@@ -50,5 +50,5 @@
 "Some applications failed to install. Support has been notified." = "Einige Programme konnten nicht installiert werden. Der Support wurde benachrichtigt.";
 
 /* Displayed above progress bar */
-"We are preparing your Mac…" = "Wir bereiten Ihren Mac vor ...";
+"We are preparing your Mac…" = "Wir bereiten Ihren Mac vor…";
 

--- a/SplashBuddy/Resources/it.lproj/Localizable.strings
+++ b/SplashBuddy/Resources/it.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "%@ failed to install. Support has been notified." = "%@ impossibile installare. Supporto è stato notificato.";
 
 /* Everything was ok. There's no button. An automated action will happen (like force restart) */
-"All applications were installed. Finishing installation…" = "Sono state installate tutte le applicazioni. Completamento installazione...";
+"All applications were installed. Finishing installation…" = "Sono state installate tutte le applicazioni. Completamento installazione…";
 
 /* (No Comment) */
 "All applications were installed. Please click continue." = "Tutte le applicazioni sono state installate. Si prega di fare clic su continua.";
@@ -50,5 +50,5 @@
 "Some applications failed to install. Support has been notified." = "Alcune applicazioni non sono state installate. Il supporto è stato notificato.";
 
 /* Displayed above progress bar */
-"We are preparing your Mac…" = "Stiamo preparando il tuo Mac...";
+"We are preparing your Mac…" = "Stiamo preparando il tuo Mac…";
 

--- a/SplashBuddy/Resources/nl.lproj/Localizable.strings
+++ b/SplashBuddy/Resources/nl.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "All applications were installed. Please click on Logout." = "Alle applicaties zijn geïnstalleerd. Klik a.u.b. op Log uit";
 
 /* Everything was ok. Asking user to click on the button */
-"All applications were installed. Please click on Quit." = "Alle applicaties zijn geïnstalleerd. Klik a.u.b. op Quit";
+"All applications were installed. Please click on Quit." = "Alle applicaties zijn geïnstalleerd. Klik a.u.b. op Beëindigen";
 
 /* Everything was ok. Asking user to click on the button */
 "All applications were installed. Please click on Restart." = "Alle applicaties zijn geïnstalleerd. Klik a.u.b. op Herstart";

--- a/SplashBuddy/Resources/nl.lproj/Localizable.strings
+++ b/SplashBuddy/Resources/nl.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "%@ failed to install. Support has been notified." = "Installatie van %@ is mislukt. Hiervan is automatisch melding gemaakt.";
 
 /* Everything was ok. There's no button. An automated action will happen (like force restart) */
-"All applications were installed. Finishing installation…" = "Alle applicaties zijn geïnstalleerd. De installatie wordt beëindigd...";
+"All applications were installed. Finishing installation…" = "Alle applicaties zijn geïnstalleerd. De installatie wordt beëindigd…";
 
 /* (No Comment) */
 "All applications were installed. Please click continue." = "Alle programma's zijn geinstalleerd. Klik op doorgaan";
@@ -29,7 +29,7 @@
 "Continue" = "Doorgaan";
 
 /* (No Comment) */
-"Installing…" = "Installeren...";
+"Installing…" = "Installeren…";
 
 /* Label of the button for Logout */
 "Logout" = "Uitloggen";
@@ -50,5 +50,5 @@
 "Some applications failed to install. Support has been notified." = "Sommige programma's konden niet geinstalleerd worden. Hiervan is automatisch melding gemaakt.";
 
 /* Displayed above progress bar */
-"We are preparing your Mac…" = "We zijn uw Mac aan het voorbereiden...";
+"We are preparing your Mac…" = "We zijn uw Mac aan het voorbereiden…";
 


### PR DESCRIPTION
minor Dutch localization 'Quit' > 'Beëndigen' (made worse by the fact that the 'Beëndigen' right next to it is localized correctly